### PR TITLE
Fix: wait for all promises to complete before redirecting to new pack

### DIFF
--- a/src/containers/TripForm/TripForm.tsx
+++ b/src/containers/TripForm/TripForm.tsx
@@ -119,13 +119,16 @@ export const TripForm: FC<Props> = ({ trip }) => {
   const onSubmit = async (data: TripFormValues) => {
     const payload = getPackPayload(data)
     const newTrip = await createTrip.mutateAsync(payload)
-    packs.forEach(async ({ title, items }) => {
-      await createPack.mutateAsync({
-        title,
-        items,
-        trip_id: newTrip.id,
+    await Promise.all(
+      packs.map(async ({ title, items }) => {
+        await createPack.mutateAsync({
+          title,
+          items,
+          trip_id: newTrip.id,
+        })
       })
-    })
+    )
+
     window.location.replace(`/pack/${newTrip.id}`)
   }
 


### PR DESCRIPTION
I noticed I ran into an error when creating packs, the same as Issue: https://github.com/Packstack-Tech/app/issues/52

``` sh
Unexpected Application Error!
undefined is not an object (evaluating 'i[o].items')
xpe@https://app.packstack.io/assets/index-61918db3.js:203:3703
a2@https://app.packstack.io/assets/index-61918db3.js:39:19539
QA@https://app.packstack.io/assets/index-61918db3.js:41:44057
YA@https://app.packstack.io/assets/index-61918db3.js:41:39789
GH@https://app.packstack.io/assets/index-61918db3.js:41:39717
xv@https://app.packstack.io/assets/index-61918db3.js:41:39570
Jw@https://app.packstack.io/assets/index-61918db3.js:41:35935
KR@https://app.packstack.io/assets/index-61918db3.js:41:36739
Pa@https://app.packstack.io/assets/index-61918db3.js:39:3280
@https://app.packstack.io/assets/index-61918db3.js:41:34265

```


This should fix it, with the caveat that the page will hang for a moment until the promises have completed. This error was particularly dangerous as if the page was redirected before the promise completed then the pack would not exist. That would be stored in the state and render the same error when trying to view other bags too, unless the user refreshed the page.

Any guidance on how to improve? I will look at adding a spinner perhaps.