### PR TITLE
Fix light mode consumable and worn icons + inventory selection visibility and consumable alignment improvements

### DIFF
--- a/src/containers/Trip/InventoryItem.tsx
+++ b/src/containers/Trip/InventoryItem.tsx
@@ -13,7 +13,7 @@ export const InventoryItem: FC<Props> = ({ item, selected, onClick }) => (
     <button
       onClick={() => onClick(item)}
       className={`p-1 w-full rounded-sm text-left border border-transparent hover:bg-muted/50 dark:hover:bg-slate-900 ${
-        selected ? '!border-muted !dark:border-accent' : ''
+        selected ? '!border-slate-400 !dark:border-accent' : ''
       }`}
     >
       <div className="text-slate-900 dark:text-slate-100 text-xs font-semibold">

--- a/src/containers/Trip/cells.tsx
+++ b/src/containers/Trip/cells.tsx
@@ -68,7 +68,11 @@ export const WornCell: FC<Props> = ({
   return (
     <button onClick={onClick}>
       <ShirtIcon
-        color={original.worn ? 'white' : '#555'}
+        className={
+          original.worn
+            ? 'stroke-slate-600  dark:stroke-white'
+            : 'stroke-slate-100 dark:stroke-slate-800'
+        }
         size={20}
         strokeWidth={1}
       />
@@ -115,7 +119,13 @@ export const WeightCell: FC<Props> = ({
     : item.weight.toFixed(2)
   return (
     <div className="inline-flex items-center gap-1">
-      {item.consumable && <FlameIcon color="white" size={16} strokeWidth={1} />}
+      {item.consumable && (
+        <FlameIcon
+          className="stroke-black dark:stroke-white"
+          size={16}
+          strokeWidth={1}
+        />
+      )}
       <span>
         {displayWeight} {item.unit}
       </span>

--- a/src/containers/Trip/cells.tsx
+++ b/src/containers/Trip/cells.tsx
@@ -118,15 +118,15 @@ export const WeightCell: FC<Props> = ({
     ? item.weight
     : item.weight.toFixed(2)
   return (
-    <div className="inline-flex items-center gap-1">
+    <div className="flex pl-1">
       {item.consumable && (
         <FlameIcon
-          className="stroke-black dark:stroke-white"
+          className="stroke-black dark:stroke-white mr-auto"
           size={16}
           strokeWidth={1}
         />
       )}
-      <span>
+      <span className="ml-auto">
         {displayWeight} {item.unit}
       </span>
     </div>


### PR DESCRIPTION
## Consumable & Worn Weight Icons, and Inventory selection
Previously, the worn weight and consumable icons were not visible in light mode. The inventory item sidebar selection border was also hard to see in both light mode and dark mode.
| Before  | After |
| ------------- | ------------- |
| ![IMG_0111](https://github.com/user-attachments/assets/ebf696a2-ba51-40e2-aa28-d4312c464355) ![IMG_0112](https://github.com/user-attachments/assets/f244dda8-7094-4c2d-be3f-84bac2b0e22f)  | ![IMG_0113](https://github.com/user-attachments/assets/739bd3ee-4f13-43dd-875d-98de456b3173) ![IMG_0114](https://github.com/user-attachments/assets/23eb10fb-73c3-45c3-9727-193185912773)  |


## Consumable icon alignment 
Previously, the consumable icons were not aligned and made it hard to read at a glance
| Before | After |
| --- | ---|
| ![IMG_0117](https://github.com/user-attachments/assets/aa8766af-c611-4901-9b63-e96da4d6efbc) | ![IMG_0116](https://github.com/user-attachments/assets/5e23cd39-554c-4973-abe2-c639cb258654) |
