### PR TITLE
Packing List Naming Convention

### DIFF
--- a/src/containers/PackingLists/PackingLists.tsx
+++ b/src/containers/PackingLists/PackingLists.tsx
@@ -95,7 +95,7 @@ export const PackingLists: FC<Props> = ({ trips }) => {
 
       <div className="flex flex-col gap-3">
         {(trips || []).map(
-          ({ created_at, start_date, end_date, id, location, removed }) => {
+          ({ created_at, start_date, end_date, id, title, location, removed }) => {
             const created = format(new Date(created_at), DATE_FORMAT)
             const start = start_date
               ? format(new Date(start_date), DATE_FORMAT)
@@ -117,8 +117,15 @@ export const PackingLists: FC<Props> = ({ trips }) => {
                       params={{ id: `${id}` }}
                       className="text-base font-semibold text-foreground hover:text-primary transition-colors"
                     >
-                      {location || 'Untitled'}
+                      {title || 'Untitled'}
                     </Link>
+
+                    {location && (
+                      <div className="mt-0.5 flex items-center gap-1.5 text-sm text-muted-foreground">
+                        <Map size={13} className="shrink-0" />
+                        <span>{location}</span>
+                      </div>
+                    )}
 
                     {start && (
                       <div className="mt-1.5 flex items-center gap-1.5 text-sm text-muted-foreground">
@@ -149,7 +156,7 @@ export const PackingLists: FC<Props> = ({ trips }) => {
                           </AlertDialogHeader>
                           <AlertDialogDescription>
                             This will create a copy of{' '}
-                            {location || 'Untitled'}.
+                            {title || 'Untitled'}.
                           </AlertDialogDescription>
                           <AlertDialogFooter>
                             <AlertDialogCancel>Cancel</AlertDialogCancel>
@@ -177,7 +184,7 @@ export const PackingLists: FC<Props> = ({ trips }) => {
                           </AlertDialogHeader>
                           <AlertDialogDescription>
                             This will permanently delete{' '}
-                            {location || 'Untitled'}.
+                            {title || 'Untitled'}.
                           </AlertDialogDescription>
                           <AlertDialogFooter>
                             <AlertDialogCancel>Cancel</AlertDialogCancel>


### PR DESCRIPTION
Currently, the packing list shows pack by location and not by the pack name you enter. This would be ok except for the fact that it automatically renames the location based on trail data. For example, I created a pack for 'Dorset' and it automatically renames it to 'Dorset Way, Dorset, England'. This effectively means you have little say in what your packs are named, which I found to be quite annoying since I was not doing the Dorset Way. 

I propose the following solution. Set the heading to whatever pack name you enter, and when a location is present, display it below the pack name. See images below. 

New:
<img width="780" height="227" alt="Screenshot 2026-04-30 at 15 25 59" src="https://github.com/user-attachments/assets/f670e88f-0e9b-4eca-9dac-fc9721be9cb6" />

Old:
<img width="780" height="227" alt="Screenshot 2026-04-30 at 15 25 44" src="https://github.com/user-attachments/assets/5fe3a093-7065-4240-99e9-cd45c3246b60" />

